### PR TITLE
6rd option added. DHCP_OPTIONS changed from record of to set of

### DIFF
--- a/src/DHCP_Options.ttcn
+++ b/src/DHCP_Options.ttcn
@@ -127,7 +127,8 @@ type enumerated DHCP_Option_Type {
   DHCP_Rebinding_Time_Value_OPTION_TYPE (59),                     //9.12
   DHCP_Relay_Agent_Information_OPTION_TYPE(82),                   //RFC3046
   DHCP_Classless_Route_OPTION_TYPE(121),                          //RFC3442
-  DHCP_Subnet_Selection_OPTION_TYPE(118)                          //RFC3011
+  DHCP_Subnet_Selection_OPTION_TYPE(118),                         //RFC3011
+  DHCP_6rd_OPTION_TYPE(212)                                       //RFC5969
 } with {
   variant "FIELDLENGTH(8)"
 }
@@ -1036,5 +1037,21 @@ type record DHCP_Classless_Route_OPTION {
   variant (len) "LENGTHTO(val)"
   variant "PRESENCE (code = DHCP_Classless_Route_OPTION_TYPE)"
 };
+
+type record length (1..infinity) of OCT4 DHCP_6rd_BR_IPv4_Address_List;
+
+type record DHCP_6rd_OPTION {
+  DHCP_Option_Type              code (DHCP_6rd_OPTION_TYPE),
+  LIN1                          len,
+  integer                       ipv4_mask_len (0..32),
+  LIN1                          prefix_len,
+  OCT16                         prefix,
+  DHCP_6rd_BR_IPv4_Address_List val
+} with {
+  variant (len) "LENGTHTO(ipv4_mask_len,prefix_len,prefix,val)"
+  variant "PRESENCE (code = DHCP_6rd_OPTION_TYPE)"
+  variant (ipv4_mask_len) "FIELDLENGTH(8)"
+};
+
 
 }with{ encode "RAW"}  // end of file

--- a/src/DHCP_Types.ttcn
+++ b/src/DHCP_Types.ttcn
@@ -147,11 +147,12 @@ type union DHCP_OPTION {
   DHCP_Relay_Agent_Information_OPTION relay_agent_information,
   DHCP_Classless_Route_OPTION classless_route,
   DHCP_Subnet_Selection_OPTION subnet_selection,
+  DHCP_6rd_OPTION six_rd,
 
   DHCP_GENERAL_OPTION general
 }
 
-type record of DHCP_OPTION DHCP_OPTIONS;
+type set of DHCP_OPTION DHCP_OPTIONS;
 
 type union DHCP_SNAME {
   DHCP_SNAME_STRING sname,


### PR DESCRIPTION
DHCP_OPTIONS changed to 'set of' as DHCP client can set options on his own preferences. This also simplifies matching mechanism as i.e. superset can be used to verify the presence of specific options. This is non backward compatible change.

As DHCP client i am testing is configured to add 6rd option i included this definition (based on rfc 5969).

Signed-off-by: Jacek Klimkowicz <jakl@semihalf.com>